### PR TITLE
Update version and fix some standards issues.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,9 +1,21 @@
-cmake -G "NMake Makefiles" -D BUILD_TESTS=OFF -D CMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% %SRC_DIR% ^
-    -DGHC_FILESYSTEM_BUILD_TESTING=OFF -DGHC_FILESYSTEM_BUILD_EXAMPLES=OFF
+:: Windows
+
+echo "================= begin ==================="
+
+:: Isolate the build
+mkdir build
+cd build
 if errorlevel 1 exit 1
 
-nmake
+:: Generate the build files
+cmake -G "Ninja" ^
+      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -DBUILD_TESTS=OFF ^
+      -DGHC_FILESYSTEM_BUILD_TESTING=OFF ^
+      -DGHC_FILESYSTEM_BUILD_EXAMPLES=OFF ^
+      %SRC_DIR%
 if errorlevel 1 exit 1
 
-nmake install
+:: Build and install
+ninja install
 if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,7 +10,7 @@ cmake -G "Ninja" ^
       %CMAKE_ARGS% ^
       -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -DBUILD_TESTS=OFF ^
-      -DGHC_FILESYSTEM_BUILD_TESTING=OFF ^
+      -DGHC_FILESYSTEM_BUILD_TESTING=ON ^
       -DGHC_FILESYSTEM_BUILD_EXAMPLES=OFF ^
       %SRC_DIR%
 if errorlevel 1 exit 1
@@ -18,3 +18,25 @@ if errorlevel 1 exit 1
 :: Build and install
 ninja install
 if errorlevel 1 exit 1
+
+:: Perform tests
+test\exception
+if errorlevel 1 exit 1
+
+test\filesystem_test
+if errorlevel 1 exit 1
+
+::test\filesystem_test_cpp17
+::if errorlevel 1 exit 1
+
+::test\filesystem_test_cpp20
+::if errorlevel 1 exit 1
+
+test\fwd_impl_test
+if errorlevel 1 exit 1
+
+test\multifile_test
+if errorlevel 1 exit 1
+
+::test\std_filesystem_test
+::if errorlevel 1 exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,7 +1,5 @@
 :: Windows
 
-echo "================= begin ==================="
-
 :: Isolate the build
 mkdir build
 cd build
@@ -9,6 +7,7 @@ if errorlevel 1 exit 1
 
 :: Generate the build files
 cmake -G "Ninja" ^
+      %CMAKE_ARGS% ^
       -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
       -DBUILD_TESTS=OFF ^
       -DGHC_FILESYSTEM_BUILD_TESTING=OFF ^

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
-cmake ${CMAKE_ARGS} -DCMAKE_INSTALL_PREFIX=$PREFIX ${SRC_DIR} -DCMAKE_INSTALL_LIBDIR=lib \
-    -DGHC_FILESYSTEM_BUILD_TESTING=OFF -DGHC_FILESYSTEM_BUILD_EXAMPLES=OFF
-make install
+# Isolate the build
+mkdir -p .build
+cd .build || exit 1
+
+# Call CMake to generate the build files
+cmake -G "Ninja" \
+      ${CMAKE_ARGS} \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_INSTALL_LIBDIR=lib \
+      -DGHC_FILESYSTEM_BUILD_TESTING=OFF \
+      -DGHC_FILESYSTEM_BUILD_EXAMPLES=OFF \
+      ${SRC_DIR} \
+      || exit 1
+
+# Build and install
+ninja install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,15 +4,33 @@
 mkdir -p .build
 cd .build || exit 1
 
+if [[ "${target_platform}" == osx-arm64 ]]; then
+    perform_test=OFF
+else
+    perform_test=ON
+fi
+
 # Call CMake to generate the build files
 cmake -G "Ninja" \
       ${CMAKE_ARGS} \
       -DCMAKE_INSTALL_PREFIX=$PREFIX \
       -DCMAKE_INSTALL_LIBDIR=lib \
-      -DGHC_FILESYSTEM_BUILD_TESTING=OFF \
+      -DGHC_FILESYSTEM_BUILD_TESTING=${perform_test} \
       -DGHC_FILESYSTEM_BUILD_EXAMPLES=OFF \
       ${SRC_DIR} \
       || exit 1
 
 # Build and install
 ninja install
+
+
+# Perform tests
+if [[ "${perform_test}" == ON ]]; then
+    test/exception || exit 1
+    test/filesystem_test || exit 1
+    #test/filesystem_test_cpp17 || exit 1
+    #test/filesystem_test_cpp20 || exit 1
+    test/fwd_impl_test || exit 1
+    test/multifile_test || exit 1
+    #test/std_filesystem_test  || exit 1
+fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,7 @@
 {% set name = "cpp-filesystem" %}
-{% set version = "1.5.8" %}
-{% set sha256 = "726f8ccb2ec844f4c66cc4b572369497327df31b86c04cefad6b311964107139" %}
+{% set version = "1.5.10" %}
+{% set sha256 = "9b96a024679807879fdfb30e46e8e461293666aeeee5fbf7f5af75aeacdfea29" %}
+{% set build_number = "0" %}
 
 package:
   name: {{ name|lower }}
@@ -12,15 +13,14 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: {{ build_number }}
   skip: true  # [win and vc<14]
 
 requirements:
   build:
     - {{ compiler('cxx') }}
     - cmake
-    - make  # [unix]
-  host: []  # Empty host dependency section
+    - ninja
 
 test:
   commands:
@@ -36,6 +36,9 @@ about:
   license_file: LICENSE
   summary: An implementation of C++17 std::filesystem
   description: An implementation of C++17 std::filesystem for C++11 /C++14/C++17 on Windows, macOS, Linux and FreeBSD.
+  dev_url: https://github.com/gulrak/filesystem
+  doc_url: https://github.com/gulrak/filesystem/blob/master/README.md#documentation
+  doc_src_url: https://github.com/gulrak/filesystem/blob/master/README.md
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ requirements:
     - ninja
 
 test:
+  # NOTE: Additional testing is performed in the build scripts (`build.sh` and `bld.bat`).
   commands:
     - test -f ${PREFIX}/include/ghc/filesystem.hpp  # [unix]
     - test -f ${PREFIX}/lib/cmake/ghc_filesystem/ghc_filesystem-config.cmake  # [unix]


### PR DESCRIPTION
# Changes

Changes:
- Update from `1.5.8` to `1.5.10`.
  - It looks like the project uses odd for dev and even for release so this is a single bump of the version.
- Add dev and doc urls.
- Prefer ninja over make + nmake.
- Remove "empty" `requirements:host` section.
- Add detailed testing to build scripts.

# Review Information

## Upstream Source

https://github.com/gulrak/filesystem

## Upstream Changes

https://github.com/gulrak/filesystem/releases

This change fixes a defect (where this package is out of sync with std::filesystem), optimizes some windows code, and fixes an overflow issue.

## Issues

https://github.com/gulrak/filesystem/issues

None that affect our users.


## Pins and Requireds

`cpp-filesystem` is a pure header only library and has no dependencies, so no pinning is necessary.

# Clossing Comments

Unfortunately, the detailed testing does not work for osx-arm64. This
may be a problem later in the packaging process for Mamba; however,
that is a fix beyond today's scope.